### PR TITLE
WIP: Pipes?

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "39b67002306fda9de4c9fd1290a6295f97edd09e",
+          "version": "7.0.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "e4fa1e85c0305ba4e0866f25812d3fa398f3a048",
+          "version": "1.1.0"
+        }
+      },
+      {
         "package": "ReactiveSwift",
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Quick",
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
-          "branch": null,
-          "revision": "e4fa1e85c0305ba4e0866f25812d3fa398f3a048",
-          "version": "1.1.0"
+          "branch": "xcode-9-fix",
+          "revision": "a3850d0ddc18cf1e6ef17b3078c660f46888deca",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,8 @@ let package = Package(
   name: "swiftsocket",
   dependencies: [
     .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "1.0.0"),
+    .package(url: "https://github.com/Quick/Quick.git", from: "1.1.0"),
+    .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.1"),
   ],
   targets: [
     .target(
@@ -24,6 +26,14 @@ let package = Package(
     .target(
       name: "support",
       dependencies: []
+    ),
+    .target(
+      name: "Pipes",
+      dependencies: []
+    ),
+    .testTarget(
+      name: "PipesTests",
+      dependencies: ["Pipes", "Quick", "Nimble"]
     ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
   name: "swiftsocket",
   dependencies: [
     .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "1.0.0"),
-    .package(url: "https://github.com/Quick/Quick.git", from: "1.1.0"),
+    .package(url: "https://github.com/Quick/Quick.git", .branch("xcode-9-fix")),
     .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.1"),
   ],
   targets: [

--- a/Sources/Pipes/CircularBuffer.swift
+++ b/Sources/Pipes/CircularBuffer.swift
@@ -7,6 +7,17 @@ public struct CircularBuffer<Element> {
     } as! Buffer
   }
 
+  public mutating func readFirst() -> Element? {
+    return buffer.modify { header, buffer in
+      guard header.count > 0 else { return nil }
+      defer {
+        header.startIndex += 1
+        header.count -= 1
+      }
+      return self[startIndex]
+    }
+  }
+
   public mutating func write(_ elements: [Element]) -> Int? {
     let capacity = buffer.capacity
     return buffer.modify { header, buffer in
@@ -16,6 +27,10 @@ public struct CircularBuffer<Element> {
       (buffer + header.count).assign(from: elements, count: count)
       return count
     }
+  }
+
+  public mutating func write(_ element: Element) -> Bool {
+    return write([element]) == 1
   }
 }
 

--- a/Sources/Pipes/CircularBuffer.swift
+++ b/Sources/Pipes/CircularBuffer.swift
@@ -1,0 +1,75 @@
+public struct CircularBuffer<Element> {
+  private let buffer: Buffer
+
+  public init(capacity: Int) {
+    buffer = Buffer.create(minimumCapacity: capacity) { _ in
+      Header(startIndex: 0, count: 0)
+    } as! Buffer
+  }
+
+  public mutating func write(_ elements: [Element]) -> Int? {
+    let capacity = buffer.capacity
+    return buffer.modify { header, buffer in
+      let available = capacity - header.count
+      let count = Swift.min(available, elements.count)
+      defer { header.count += count }
+      (buffer + header.count).assign(from: elements, count: count)
+      return count
+    }
+  }
+}
+
+private extension CircularBuffer {
+  struct Header {
+    var startIndex: Int
+    var count: Int
+  }
+
+  final class Buffer: ManagedBuffer<Header, Element> {
+    func modify<Result>(_ body: (inout Header, UnsafeMutablePointer<Element>) -> Result) -> Result {
+      return withUnsafeMutablePointers { header, elements in
+        return body(&header.pointee, elements)
+      }
+    }
+
+    func position(for offset: Int) -> Int {
+      let position = header.startIndex + offset
+      if position < capacity {
+        return position
+      } else {
+        return capacity - position
+      }
+    }
+  }
+}
+
+extension CircularBuffer: Collection {
+  public struct Index: Comparable {
+    fileprivate var offset: Int
+
+    public static func == (lhs: Index, rhs: Index) -> Bool {
+      return lhs.offset == rhs.offset
+    }
+
+    public static func < (lhs: Index, rhs: Index) -> Bool {
+      return lhs.offset < rhs.offset
+    }
+  }
+
+  public var startIndex: Index {
+    return Index(offset: 0)
+  }
+
+  public var endIndex: Index {
+    return Index(offset: buffer.header.count)
+  }
+
+  public func index(after i: Index) -> Index {
+    return Index(offset: i.offset + 1)
+  }
+
+  public subscript(index: Index) -> Element {
+    let position = buffer.position(for: index.offset)
+    return buffer.withUnsafeMutablePointerToElements { $0[position] }
+  }
+}

--- a/Sources/Pipes/Pipe.swift
+++ b/Sources/Pipes/Pipe.swift
@@ -1,0 +1,28 @@
+import Dispatch
+
+public final class Pipe<Element> {
+  private var buffer: CircularBuffer<Element>
+  private let source: DispatchSourceUserDataAdd
+
+  public init(capacity: Int, queue: DispatchQueue, handler: @escaping (inout CircularBuffer<Element>) -> Void) {
+    buffer = CircularBuffer(capacity: capacity)
+    source = DispatchSource.makeUserDataAddSource(queue: queue)
+
+    source.setEventHandler {
+      handler(&self.buffer)
+      self.source.add(data: self.availableData)
+    }
+
+    source.resume()
+  }
+
+  public func write(_ element: Element) {
+    if buffer.write(element) {
+      source.add(data: 1)
+    }
+  }
+
+  private var availableData: UInt {
+    return UInt(buffer.count)
+  }
+}

--- a/Tests/PipesTests/CircularBufferTests.swift
+++ b/Tests/PipesTests/CircularBufferTests.swift
@@ -1,0 +1,22 @@
+import Pipes
+import Quick
+import Nimble
+import XCTest
+
+final class CircularBufferTests: QuickSpec {
+  override func spec() {
+    describe("write") {
+      it("can write less than the buffer capacity") {
+        var buffer = CircularBuffer<Int>(capacity: 5)
+        expect(buffer.write([1, 2, 3])) == 3
+        expect(Array(buffer)) == [1, 2, 3]
+      }
+
+      it("writes as much as possible up to the capacity") {
+        var buffer = CircularBuffer<Int>(capacity: 2)
+        expect(buffer.write([1, 2, 3])) == 2
+        expect(Array(buffer)) == [1, 2]
+      }
+    }
+  }
+}

--- a/Tests/PipesTests/CircularBufferTests.swift
+++ b/Tests/PipesTests/CircularBufferTests.swift
@@ -17,6 +17,26 @@ final class CircularBufferTests: QuickSpec {
         expect(buffer.write([1, 2, 3])) == 2
         expect(Array(buffer)) == [1, 2]
       }
+
+      it("supports writing a single element") {
+        var buffer = CircularBuffer<Int>(capacity: 1)
+        expect(buffer.write(123)) == true
+        expect(Array(buffer)) == [123]
+      }
+    }
+
+    describe("readFirst()") {
+      it("removes the first element from the buffer") {
+        var buffer = CircularBuffer<Int>(capacity: 3)
+        _ = buffer.write([1, 2])
+        expect(buffer.readFirst()) == 1
+        expect(Array(buffer)) == [2]
+      }
+
+      it("returns nil if the buffer is empty") {
+        var buffer = CircularBuffer<Int>(capacity: 1)
+        expect(buffer.readFirst()).to(beNil())
+      }
     }
   }
 }

--- a/Tests/PipesTests/PipeSpec.swift
+++ b/Tests/PipesTests/PipeSpec.swift
@@ -1,0 +1,35 @@
+import Pipes
+import Quick
+import Nimble
+
+final class PipeSpec: QuickSpec {
+  override func spec() {
+    it("calls the event handler when data is available in the buffer") {
+      var value: Int?
+
+      let pipe = Pipe<Int>(capacity: 1, queue: .main) { buffer in
+        value = buffer.readFirst()
+      }
+
+      pipe.write(123)
+
+      expect(value).toEventually(equal(123))
+    }
+
+    it("calls the handler if data is still available after reading") {
+      var values: [Int] = []
+
+      let pipe = Pipe<Int>(capacity: 2, queue: .main) { buffer in
+        if let value = buffer.readFirst() {
+          values.append(value)
+        }
+      }
+
+      pipe.write(1)
+      expect(values).to(beEmpty())
+      pipe.write(2)
+
+      expect(values).toEventually(equal([1, 2]))
+    }
+  }
+}


### PR DESCRIPTION
Exploring the idea of introducing a `Pipe<Element>` abstraction to encapsulate:

1. A buffer holding values of type `Element`
2. A dispatch source that generates events when data is available to read

We already have this for reading data from a socket: the buffer is provided by the kernal, and the data is read using non-blocking I/O whenever.

I'm hoping to generalise this idea to make it possible to have little process connected in a "pipes and filters style", to achieve the following archicture:

1. The read end of the socket would be a `Pipe<UInt8>`.
2. A HTTP request tokeniser would read bytes and write them into a `Pipe<HTTPRequest.Token>`
3. More HTTP stuff could happen, potentially forming layers of middleware, writing it to `Pipe<HTTPRequest>` or something
4. An application-level process could read the `HTTPRequest` and write to something like `Pipe<HTTPResponse>`
5. Finally, we'd serialize the response and write to `Pipe<UInt8>` again

For a given connection, each `Pipe` in this pipeline would have a `DispatchSource`, and they would all target the same serial `DispatchQueue`.
This would allow requests to be handled in parallel, and all the buffers at each connection in the pipeline should be able to safely reuse shared memory, because only a single process in the pipeline would ever be executing at once (for a given request).

---

I'm starting by pushing up the beginings of a `CircularBuffer<Element>` struct, that I'm hoping could form the internal buffer for these custom pipes.